### PR TITLE
Fix typo in zypper command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ zin\
      thunar thunar-plugin-archive engrampa
 
 log "Installing development tools"
-sudo zyppe in -yl\
+zin\
      emacs git zsh podman flatpak buildah
 
 log "Installing theme assets"


### PR DESCRIPTION
Fix a typo in zypper command and replace it by the defined alias.